### PR TITLE
Added validity to SAS token generation

### DIFF
--- a/Limpet/Limpet.NET/Limpet.cs
+++ b/Limpet/Limpet.NET/Limpet.cs
@@ -307,6 +307,7 @@ namespace Microsoft.Devices.Tpm
             string deviceId = GetDeviceId();
             string hostName = GetHostName();
             long expirationTime = (DateTime.Now.ToUniversalTime().ToFileTime() / WINDOWS_TICKS_PER_SEC) - EPOCH_DIFFERNECE;
+            expirationTime += validity;
             string sasToken = "";
             if ((hostName.Length > 0) && (deviceId.Length > 0))
             {


### PR DESCRIPTION
Limpet.cs TpmDevice class GetSASToken function validity parameter value is now added to the expiry time.
- The parameter was completely unused and resulted in SAS tokens that are only valid until the current moment in time, resulting in failure around 5 minutes later

Addresses issues #10 and #11.