### PR TITLE
Updated macros to support RSA_3072 and RSA_4096

### DIFF
--- a/Urchin/Inc/UrchinLib.h
+++ b/Urchin/Inc/UrchinLib.h
@@ -299,12 +299,24 @@ typedef struct {
 #define    CC_ZGen_2Phase                   YES    // 1
 #define    CC_EC_Ephemeral                  YES    // 1
 
-
 // Table 215 -- RSA Algorithm Constants
-#define    RSA_KEY_SIZES_BITS    {1024, 2048}    // {1024,2048}
-#define    MAX_RSA_KEY_BITS      2048
-#define    MAX_RSA_KEY_BYTES     ((MAX_RSA_KEY_BITS + 7) / 8)    // 256
-
+#define    RSA_KEY_SIZES_BITS    {1024, 2048, 3072, 4096}    // {1024,2048,3072,4096}
+#define    MAX_RSA_KEY_BITS	     4096
+#define    RSA_KEY_BYTES(bits)   ((bits + 7) / 8)
+#define    MAX_RSA_KEY_BYTES     RSA_KEY_BYTES(MAX_RSA_KEY_BITS)    // 512
+enum RSA_KEY_TYPE
+{
+	RSA_1024 = 0,	// RSA_1024
+	RSA_2048,		// RSA_2048
+	RSA_3072,		// RSA_3072
+	RSA_4096,		// RSA_4096
+	RSA_KEY_TYPE_MAX
+};
+static const UINT16 RSA_KEYBITS[RSA_KEY_TYPE_MAX] = RSA_KEY_SIZES_BITS;
+#define    RSA_1024_KEYBITS	     RSA_KEYBITS[RSA_1024]
+#define    RSA_2048_KEYBITS	     RSA_KEYBITS[RSA_2048]
+#define    RSA_3072_KEYBITS	     RSA_KEYBITS[RSA_3072]
+#define    RSA_4096_KEYBITS	     RSA_KEYBITS[RSA_4096]
 
 // Table 216 -- ECC Algorithm Constants
 #define    ECC_CURVES            {\
@@ -13073,10 +13085,12 @@ extern UINT32 g_CommandTimeout;
 #define TPM_DEFAULT_COMMAND_TIMEOUT (2000) // 2 seconds should be OK for all non-create commands
 #define TPM_CREATE_COMMAND_TIMEOUT (90000) // 90 seconds should cover all create commands
 void SetEkTemplate(
-TPM2B_PUBLIC *publicArea         // OUT: public area of EK object
+TPM2B_PUBLIC *publicArea,                   // OUT: public area of EK object
+UINT16 rsaKeyBits = RSA_2048_KEYBITS        // IN:  Size of the RSA keybits to be used, default to RSA_2048_KEYBITS for backward compatibility
 );
 void SetSrkTemplate(
-TPM2B_PUBLIC *publicArea         // OUT: public area of SRK object
+TPM2B_PUBLIC *publicArea,                   // OUT: public area of SRK object
+UINT16 rsaKeyBits = RSA_2048_KEYBITS        // IN:  Size of the RSA keybits to be used, default to RSA_2048_KEYBITS for backward compatibility
 );
 
 #ifdef URCHIN_DEBUG

--- a/Urchin/Lib/CmdProcessor.cpp
+++ b/Urchin/Lib/CmdProcessor.cpp
@@ -908,7 +908,8 @@ TPM2B_ID_OBJECT     *outIDObject    // OUT: output credential
 
 // Windows8 defined TPM 2.0 default Template
 void SetEkTemplate(
-    TPM2B_PUBLIC *publicArea
+    TPM2B_PUBLIC *publicArea,
+    UINT16 rsaKeyBitsSize
     )
 {
     const BYTE TPM_20_EK_AUTH_POLICY[] =  // 'PolicySecret(TPM_RH_ENDORSEMENT)'
@@ -924,7 +925,7 @@ void SetEkTemplate(
                sizeof(TPM_20_EK_AUTH_POLICY),
                sizeof(publicArea->t.publicArea.authPolicy.t.buffer));
     publicArea->t.publicArea.authPolicy.t.size = sizeof(TPM_20_EK_AUTH_POLICY);
-    publicArea->t.publicArea.unique.rsa.t.size = MAX_RSA_KEY_BITS / 8;
+    publicArea->t.publicArea.unique.rsa.t.size = rsaKeyBitsSize / 8;
     publicArea->t.publicArea.type = TPM_ALG_RSA;
     publicArea->t.publicArea.nameAlg = TPM_ALG_SHA256;
     publicArea->t.publicArea.objectAttributes.fixedTPM = SET;
@@ -933,7 +934,7 @@ void SetEkTemplate(
     publicArea->t.publicArea.objectAttributes.adminWithPolicy = SET;
     publicArea->t.publicArea.objectAttributes.restricted = SET;
     publicArea->t.publicArea.objectAttributes.decrypt = SET;
-    publicArea->t.publicArea.parameters.rsaDetail.keyBits = MAX_RSA_KEY_BITS;
+    publicArea->t.publicArea.parameters.rsaDetail.keyBits = rsaKeyBitsSize;
     publicArea->t.publicArea.parameters.rsaDetail.exponent = 0;
     publicArea->t.publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_NULL;
     publicArea->t.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
@@ -942,7 +943,8 @@ void SetEkTemplate(
 };
 
 void SetSrkTemplate(
-    TPM2B_PUBLIC *publicArea
+    TPM2B_PUBLIC *publicArea,
+    UINT16 rsaKeyBitsSize
     )
 {
     if (publicArea == NULL) return;
@@ -955,13 +957,13 @@ void SetSrkTemplate(
     publicArea->t.publicArea.objectAttributes.noDA = SET;
     publicArea->t.publicArea.objectAttributes.restricted = SET;
     publicArea->t.publicArea.objectAttributes.decrypt = SET;
-    publicArea->t.publicArea.parameters.rsaDetail.keyBits = MAX_RSA_KEY_BITS;
+    publicArea->t.publicArea.parameters.rsaDetail.keyBits = rsaKeyBitsSize;
     publicArea->t.publicArea.parameters.rsaDetail.exponent = 0;
     publicArea->t.publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_NULL;
     publicArea->t.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
     publicArea->t.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
     publicArea->t.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_CFB;
-    publicArea->t.publicArea.unique.rsa.t.size = MAX_RSA_KEY_BITS / 8;
+    publicArea->t.publicArea.unique.rsa.t.size = rsaKeyBitsSize / 8;
 };
 
 //*** ObjectComputeName()

--- a/Urchin/Lib/Marshal.cpp
+++ b/Urchin/Lib/Marshal.cpp
@@ -4258,6 +4258,8 @@ TPMI_RSA_KEY_BITS_Unmarshal(TPMI_RSA_KEY_BITS *target, BYTE **buffer, INT32 *siz
     switch (*target) {
         case 1024:
         case 2048:
+        case 3072:
+        case 4096:
             break;
         default:
             return TPM_RC_VALUE;


### PR DESCRIPTION
Crypto is moving towards more secure algorithms.
And as a user of this library, we have a need to generate/use 3K RSA keys in/from the TPM.
The current implementation of the Urchin library supports only up to 2048 key bits RSA.
I am suggesting this patch to support RSA keys up to 4096 key bits. 
The other TPM libraries like Intel's "tpm2-tss" open source project supports up to 4K RSA keys.
Thank you.


Signed-off-by: Gunj Manseta <gumanset@microsoft.com>