### PR TITLE
added missed macro use in Unmarshal

### DIFF
--- a/Urchin/Lib/Marshal.cpp
+++ b/Urchin/Lib/Marshal.cpp
@@ -4258,8 +4258,12 @@ TPMI_RSA_KEY_BITS_Unmarshal(TPMI_RSA_KEY_BITS *target, BYTE **buffer, INT32 *siz
     switch (*target) {
         case 1024:
         case 2048:
+#if defined(ENABLE_RSA_3072) || defined(ENABLE_RSA_4096)
         case 3072:
+#endif
+#if defined(ENABLE_RSA_4096)
         case 4096:
+#endif
             break;
         default:
             return TPM_RC_VALUE;


### PR DESCRIPTION
Added missed Built tag introduced in previous commit to Unmarshal code.

Signed-off-by: Gunj Manseta gumanset@microsoft.com